### PR TITLE
Added Inference Spec & CI

### DIFF
--- a/.github/workflows/deploy_inference_apps.yaml
+++ b/.github/workflows/deploy_inference_apps.yaml
@@ -1,0 +1,84 @@
+name: Deploy Inference Apps
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  id-token: write  
+  contents: read    
+
+jobs:
+  deploy_dev:
+    name: Deploy Inference Apps (Development)
+    runs-on: ubuntu-latest
+    env:
+      ENV: dev
+      AWS_REGION: us-east-1
+      AWS_CI_ROLE: ${{ secrets.AWS_INFER_CI_ROLE__DEV }}
+    steps: 
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_CI_ROLE}}
+
+      - name: Deploy Ray Serve
+        shell: bash
+        run: |
+          RAY_CLUSTER_NAME=ray-cluster-$ENV
+          RAY_PRIVATE_IP=$(aws ec2 describe-instances --region $AWS_DEFAULT_REGION --filters "Name=tag:Name,Values=ray-cluster-$ENV-head" --query "Reservations[*].Instances[*].PrivateIpAddress" --output text)
+          RAY_BASTION_PUBLIC_IP=$(aws ec2 describe-instances --region $AWS_DEFAULT_REGION --filters "Name=tag:Name,Values=ray-cluster-$ENV-bastion" --query "Reservations[*].Instances[*].PublicIpAddress" --output text)
+          RAY_CLUSTER_KEY_PAIR_FILE=$RAY_CLUSTER_NAME
+          RAY_CLUSTER_SECRET_KEY_PAIR_NAME=$RAY_CLUSTER_NAME-key-pair-secret
+
+          aws secretsmanager get-secret-value --region $AWS_REGION --secret-id $RAY_CLUSTER_SECRET_KEY_PAIR_NAME --query SecretString --output text > ./${RAY_CLUSTER_KEY_PAIR_FILE}.pem
+          chmod 400 ./${RAY_CLUSTER_KEY_PAIR_FILE}.pem
+
+          echo "Deploying Ray Serve on $RAY_CLUSTER_NAME..."
+          if ssh -o StrictHostKeyChecking=no -i ./${RAY_CLUSTER_KEY_PAIR_FILE}.pem ubuntu@$RAY_BASTION_PUBLIC_IP "source ~/.profile && bash bastion-ray-serve-deploy.sh $ENV" >/dev/null 2>&1; then
+            echo "Deployment succeeded."
+          else
+            echo "Deployment failed."
+            exit 1
+          fi
+
+  deploy_prod:
+    name: Deploy Inference Apps (Production)
+    runs-on: ubuntu-latest
+    depends-on: deploy_dev
+    env:
+      ENV: prod
+      AWS_REGION: us-east-1
+      AWS_CI_ROLE: ${{ secrets.AWS_INFER_CI_ROLE__PROD }}
+    steps: 
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_CI_ROLE}}
+
+      - name: Deploy Ray Serve
+        shell: bash
+        run: |
+          RAY_CLUSTER_NAME=ray-cluster-$ENV
+          RAY_PRIVATE_IP=$(aws ec2 describe-instances --region $AWS_DEFAULT_REGION --filters "Name=tag:Name,Values=ray-cluster-$ENV-head" --query "Reservations[*].Instances[*].PrivateIpAddress" --output text)
+          RAY_BASTION_PUBLIC_IP=$(aws ec2 describe-instances --region $AWS_DEFAULT_REGION --filters "Name=tag:Name,Values=ray-cluster-$ENV-bastion" --query "Reservations[*].Instances[*].PublicIpAddress" --output text)
+          RAY_CLUSTER_KEY_PAIR_FILE=$RAY_CLUSTER_NAME
+          RAY_CLUSTER_SECRET_KEY_PAIR_NAME=$RAY_CLUSTER_NAME-key-pair-secret
+
+          aws secretsmanager get-secret-value --region $AWS_REGION --secret-id $RAY_CLUSTER_SECRET_KEY_PAIR_NAME --query SecretString --output text > ./${RAY_CLUSTER_KEY_PAIR_FILE}.pem
+          chmod 400 ./${RAY_CLUSTER_KEY_PAIR_FILE}.pem
+
+          echo "Deploying Ray Serve on $RAY_CLUSTER_NAME..."
+          if ssh -o StrictHostKeyChecking=no -i ./${RAY_CLUSTER_KEY_PAIR_FILE}.pem ubuntu@$RAY_BASTION_PUBLIC_IP "source ~/.profile && bash bastion-ray-serve-deploy.sh $ENV" >/dev/null 2>&1; then
+            echo "Deployment succeeded."
+          else
+            echo "Deployment failed."
+            exit 1
+          fi
+      

--- a/app_inference_spec.py
+++ b/app_inference_spec.py
@@ -1,0 +1,78 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import List, Union, cast
+import torch
+import os
+from models_host.base_inference_spec import BaseInferenceSpec
+
+from transformers import pipeline
+    
+class InferenceData(BaseModel):
+    name: str
+    shape: List[int]
+    data: List
+    datatype: str
+
+class InputRequest(BaseModel):
+    inputs: List[InferenceData]
+
+class OutputResponse(BaseModel):
+    modelname: str
+    modelversion: str
+    outputs: List[InferenceData]
+
+class InferenceSpec(BaseInferenceSpec):
+    model_name = "michellejieli/NSFW_text_classifier"
+    
+    @property
+    def torch_device(self):
+        env = os.environ.get("env", "dev")
+        torch_device = "cuda" if env == "prod" else "cpu"
+        return torch_device
+    
+    def load(self):
+        model_name = self.model_name
+        torch_device = self.torch_device
+        print(f"Loading model {model_name} using device {torch_device}...")
+        self.model = pipeline(
+            "text-classification", 
+            model=model_name,
+            device=torch_device
+        )
+    
+    def process_request(self, input_request: InputRequest) -> OutputResponse:
+        threshold = None
+        for inp in input_request.inputs:
+            if inp.name == "text":
+                text_vals = inp.data
+            elif inp.name == "threshold":
+                threshold = float(inp.data[0])
+
+        if text_vals is None or threshold is None:
+            raise HTTPException(status_code=400, detail="Invalid input format")
+
+        args = (text_vals, threshold)
+        kwargs = {} 
+        return args, kwargs
+    
+    def infer(self, text_vals, threshold) -> OutputResponse:
+        outputs = []
+        for idx, text in enumerate(text_vals):
+            results = self.model(text)
+            pred_labels = [
+                result['label'] for result in results if result['label'] == 'NSFW' and result['score'] > threshold
+            ]
+            outputs.append(
+                InferenceData(
+                    name=f"result{idx}",
+                    datatype="BYTES",
+                    shape=[len(pred_labels)],
+                    data=[pred_labels],
+                )
+            )
+
+        output_data = OutputResponse(
+            modelname=self.model_name, modelversion="1", outputs=outputs
+        )
+
+        return output_data

--- a/app_inference_spec.py
+++ b/app_inference_spec.py
@@ -37,7 +37,7 @@ class InferenceSpec(BaseInferenceSpec):
         self.model = pipeline(
             "text-classification", 
             model=model_name,
-            device=torch_device
+            device=torch.device(torch_device)
         )
     
     def process_request(self, input_request: InputRequest) -> OutputResponse:

--- a/app_inference_spec.py
+++ b/app_inference_spec.py
@@ -1,6 +1,6 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import HTTPException
 from pydantic import BaseModel
-from typing import List, Union, cast
+from typing import List, Tuple
 import torch
 import os
 from models_host.base_inference_spec import BaseInferenceSpec
@@ -40,7 +40,7 @@ class InferenceSpec(BaseInferenceSpec):
             device=torch.device(torch_device)
         )
     
-    def process_request(self, input_request: InputRequest) -> OutputResponse:
+    def process_request(self, input_request: InputRequest) -> Tuple[Tuple, dict]:
         threshold = None
         for inp in input_request.inputs:
             if inp.name == "text":

--- a/example_inference.json
+++ b/example_inference.json
@@ -1,0 +1,16 @@
+{
+    "inputs": [
+        {
+            "name": "text",
+            "shape": [1],
+            "data": ["I want to go nude"],
+            "datatype": "BYTES"
+        },
+        {
+            "name": "threshold",
+            "shape": [1],
+            "data": [0.5],
+            "datatype": "FP32"
+        }
+    ]
+}


### PR DESCRIPTION
Added:
- Added Inference Spec class to support Ray, Sagemaker, FastAPI in one go
- Added CI to support to deploy/update validator's inference endpoint on the cluster

Example Running FastAPI with Inference Spec:

```bash
pip install git+https://github.com/guardrails-ai/models-host@feat/adding-ray-setup
uvicorn models_host.fastapi:app
```

Example Running Ray Serve with Inference Spec:

```bash
# Refer to models-host repo for instructions if you don't have a GPU on the machine running ray serve
pip install git+https://github.com/guardrails-ai/models-host@feat/adding-ray-setup
serve run models_host.ray_serve:app
```